### PR TITLE
FEATURE: Propagate indirect props to the wrapping node

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ export default class ClickOutside extends Component {
   };
 
   render() {
-    const { children } = this.props
-    return <div>{children}</div>
+    const { children, ...props } = this.props
+    return <div {...props}>{children}</div>
   }
 
   componentDidMount() {


### PR DESCRIPTION
This allows users to specify id's or other standard react props to be passed to the wrapping react-click-outside node. For example

```
<ClickOutside id="myNodeId" className="myWrappingClassName" onClickOutside={::this.close}>
  <p>Im a menu or something that you want to hide when clicking outside.</p>
</ClickOutside>
```