### PR TITLE
Do not pass all props to the wrapper div

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ export default class ClickOutside extends Component {
   };
 
   render() {
-    const { children, onClickOutside, ...props } = this.props
-    return <div {...props} ref='container'>{children}</div>
+    const { children, onClickOutside } = this.props
+    return <div ref='container'>{children}</div>
   }
 
   componentDidMount() {


### PR DESCRIPTION
React shows this warning for invalid props on regular HTML elements.

```
Warning: Unknown prop `onClickOutside` on <div> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
```

We need to avoid using `{...this.props}` on those elements, and generally it doesn't work with PropTypes so not a very good idea.