### PR TITLE
Uses ref callback for getting element reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ export default class ClickOutside extends Component {
 
   render() {
     const { children, onClickOutside, ...props } = this.props
-    return <div {...props} ref='container'>{children}</div>
+    return <div {...props} ref={ref => this.container = ref}>{children}</div>
   }
 
   componentDidMount() {
@@ -21,7 +21,7 @@ export default class ClickOutside extends Component {
 
   handle = e => {
     const { onClickOutside } = this.props
-    const el = this.refs.container
+    const el = this.container
     if (!el.contains(e.target)) onClickOutside(e)
   };
 }


### PR DESCRIPTION
The React team now advises against using string references, recommending the callback function form. This is a small, negligible change, but helps to illustrate current best practices.