### PR TITLE
add touchend event for iOS support

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -38,7 +38,10 @@ var ClickOutside = function (_Component) {
       var onClickOutside = _this.props.onClickOutside;
 
       var el = _this.container;
-      if (!el.contains(e.target)) onClickOutside(e);
+      if (!el.contains(e.target)) {
+        e.preventDefault();
+        onClickOutside(e);
+      }
     };
 
     _this.getContainer = _this.getContainer.bind(_this);
@@ -67,11 +70,13 @@ var ClickOutside = function (_Component) {
   }, {
     key: 'componentDidMount',
     value: function componentDidMount() {
+      document.addEventListener('touchend', this.handle, true);
       document.addEventListener('click', this.handle, true);
     }
   }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
+      document.removeEventListener('touchend', this.handle, true);
       document.removeEventListener('click', this.handle, true);
     }
   }]);

--- a/index.js
+++ b/index.js
@@ -22,16 +22,21 @@ export default class ClickOutside extends Component {
   }
 
   componentDidMount() {
+    document.addEventListener('touchend', this.handle, true)
     document.addEventListener('click', this.handle, true)
   }
 
   componentWillUnmount() {
+    document.removeEventListener('touchend', this.handle, true)
     document.removeEventListener('click', this.handle, true)
   }
 
   handle = e => {
     const { onClickOutside } = this.props
     const el = this.container
-    if (!el.contains(e.target)) onClickOutside(e)
+    if (!el.contains(e.target)) {
+      e.preventDefault()
+      onClickOutside(e)
+    }
   };
 }


### PR DESCRIPTION
Instead of using the body-cursor-pointer hack I propose this as a simple solution.

The `e.preventDefault()` makes sure that only `touchend` or `click` is triggered.

This solution won't work if the `ClickOutside` component is in the DOM at all times because it will prevent every other click- and touchend action like clicking a link. Just to make a fair point against this.

In my opinion that's not the use case for this component.

Cheers