### PR TITLE
Bug fix: check when el is null

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -40,7 +40,7 @@ var ClickOutside = function (_Component) {
       var onClickOutside = _this.props.onClickOutside;
 
       var el = _this.container;
-      if (!el.contains(e.target)) onClickOutside(e);
+      if (el && !el.contains(e.target)) onClickOutside(e);
     };
 
     _this.getContainer = _this.getContainer.bind(_this);

--- a/index.js
+++ b/index.js
@@ -36,6 +36,6 @@ export default class ClickOutside extends Component {
     if (e.type === 'click' && this.isTouch) return
     const { onClickOutside } = this.props
     const el = this.container
-    if (!el.contains(e.target)) onClickOutside(e)
+    if (el && !el.contains(e.target)) onClickOutside(e)
   }
 }


### PR DESCRIPTION
While using multiple instances on Styleguidist I ran into this issue. It causes a huge performance degradation on the page.

```
Uncaught TypeError: Cannot read property 'contains' of null
    at HTMLDocument.ClickOutside._this.handle (index.js:43)
```