### PR TITLE
Add support for right click

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,11 +24,13 @@ export default class ClickOutside extends Component {
   componentDidMount() {
     document.addEventListener('touchend', this.handle, true)
     document.addEventListener('click', this.handle, true)
+    document.addEventListener('contextmenu', this.handle, true)
   }
 
   componentWillUnmount() {
     document.removeEventListener('touchend', this.handle, true)
     document.removeEventListener('click', this.handle, true)
+    document.removeEventListener('contextmenu', this.handle, true)
   }
 
   handle = e => {


### PR DESCRIPTION
This PR introduces support on `onClickOutside` for right clicks.

If this seems too opinionated, maybe we can create an `allowRightClick: boolean` prop to make it more flexible.