### PR TITLE
Allow for screens that have both touch and click

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,10 @@ export default class ClickOutside extends Component {
 
   handle = e => {
     if (e.type === 'touchend') this.isTouch = true
-    if (e.type === 'click' && this.isTouch) return
+    if (e.type === 'click' && this.isTouch) {
+      this.isTouch = false;
+      return;
+    }
     const { onClickOutside } = this.props
     const el = this.container
     if (el && !el.contains(e.target)) onClickOutside(e)


### PR DESCRIPTION
Some screens like the a Lenovo Yoga have both touch and click capabilities. A bug exists in that if a user uses the touch screen, they would not be able to click this once they switch back to mouse. This fix allows the user to switch between the two.