### PR TITLE
fix: unable to trigger onClickOutside once mobile client resize to PC client.

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -43,6 +43,10 @@ var ClickOutside = function (_Component) {
       if (el && !el.contains(e.target)) onClickOutside(e);
     };
 
+    _this.resetIsTouch = function () {
+      return _this.isTouch = false;
+    };
+
     _this.getContainer = _this.getContainer.bind(_this);
     _this.isTouch = false;
     return _this;
@@ -72,12 +76,14 @@ var ClickOutside = function (_Component) {
     value: function componentDidMount() {
       document.addEventListener('touchend', this.handle, true);
       document.addEventListener('click', this.handle, true);
+      window.addEventListener('resize', this.resetIsTouch, true);
     }
   }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
       document.removeEventListener('touchend', this.handle, true);
       document.removeEventListener('click', this.handle, true);
+      window.removeEventListener('resize', this.resetIsTouch, true);
     }
   }]);
 

--- a/index.js
+++ b/index.js
@@ -24,11 +24,13 @@ export default class ClickOutside extends Component {
   componentDidMount() {
     document.addEventListener('touchend', this.handle, true)
     document.addEventListener('click', this.handle, true)
+    window.addEventListener('resize', this.resetIsTouch, true)
   }
 
   componentWillUnmount() {
     document.removeEventListener('touchend', this.handle, true)
     document.removeEventListener('click', this.handle, true)
+    window.removeEventListener('resize', this.resetIsTouch, true)
   }
 
   handle = e => {
@@ -38,4 +40,6 @@ export default class ClickOutside extends Component {
     const el = this.container
     if (el && !el.contains(e.target)) onClickOutside(e)
   }
+
+  resetIsTouch = () => this.isTouch = false
 }


### PR DESCRIPTION
I added the following code:

```js
window.addEventListener('resize', this.resetIsTouch, true)

window.removeEventListener('resize', this.resetIsTouch, true)

resetIsTouch = () => this.isTouch = false
```

to ensure the code below can be executed normally:

```js
handle = e => {
  if (e.type === 'touchend') this.isTouch = true
  if (e.type === 'click' && this.isTouch) return
  const { onClickOutside } = this.props
  const el = this.container
  if (el && !el.contains(e.target)) onClickOutside(e)
}
```

while the browser switches from mobile mode to PC mode.